### PR TITLE
Better names for enum variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "shader_version"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["shader", "version", "OpenGL", "GLSL", "piston"]
 description = "A helper library for detecting and picking compatible shaders"

--- a/src/glsl.rs
+++ b/src/glsl.rs
@@ -10,37 +10,37 @@ use { OpenGL, PickShader, Shaders };
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
 pub enum GLSL {
-    _1_10,
-    _1_20,
-    _1_30,
-    _1_40,
-    _1_50,
-    _3_30,
-    _4_00,
-    _4_10,
-    _4_20,
-    _4_30,
-    _4_40,
-    _4_50
+    V1_10,
+    V1_20,
+    V1_30,
+    V1_40,
+    V1_50,
+    V3_30,
+    V4_00,
+    V4_10,
+    V4_20,
+    V4_30,
+    V4_40,
+    V4_50
 }
 
 impl GLSL {
     /// Gets OpenGL version associated with GLSL.
     #[allow(non_snake_case)]
-    pub fn to_OpenGL(&self) -> OpenGL {
+    pub fn to_opengl(&self) -> OpenGL {
         match *self {
-            GLSL::_1_10 => OpenGL::_2_0,
-            GLSL::_1_20 => OpenGL::_2_1,
-            GLSL::_1_30 => OpenGL::_3_0,
-            GLSL::_1_40 => OpenGL::_3_1,
-            GLSL::_1_50 => OpenGL::_3_2,
-            GLSL::_3_30 => OpenGL::_3_3,
-            GLSL::_4_00 => OpenGL::_4_0,
-            GLSL::_4_10 => OpenGL::_4_1,
-            GLSL::_4_20 => OpenGL::_4_2,
-            GLSL::_4_30 => OpenGL::_4_3,
-            GLSL::_4_40 => OpenGL::_4_4,
-            GLSL::_4_50 => OpenGL::_4_5
+            GLSL::V1_10 => OpenGL::V2_0,
+            GLSL::V1_20 => OpenGL::V2_1,
+            GLSL::V1_30 => OpenGL::V3_0,
+            GLSL::V1_40 => OpenGL::V3_1,
+            GLSL::V1_50 => OpenGL::V3_2,
+            GLSL::V3_30 => OpenGL::V3_3,
+            GLSL::V4_00 => OpenGL::V4_0,
+            GLSL::V4_10 => OpenGL::V4_1,
+            GLSL::V4_20 => OpenGL::V4_2,
+            GLSL::V4_30 => OpenGL::V4_3,
+            GLSL::V4_40 => OpenGL::V4_4,
+            GLSL::V4_50 => OpenGL::V4_5
         }
     }
 }
@@ -49,10 +49,10 @@ impl PickShader for GLSL {
     fn pick_shader<'a, S: ?Sized>(self, shaders: &Shaders<'a, Self, S>) -> Option<&'a S> {
         // OpenGL since 3.2 in core profile doesn't support GLSL lower than 1.50.
         // Since there are no compatible shader in this case, it will return `None`.
-        let low = if self < GLSL::_1_50 {
-            GLSL::_1_10
+        let low = if self < GLSL::V1_50 {
+            GLSL::V1_10
         } else {
-            GLSL::_1_50
+            GLSL::V1_50
         };
         shaders.0.iter()
                .skip_while(|&(v, _)| *v < low)

--- a/src/opengl.rs
+++ b/src/opengl.rs
@@ -6,55 +6,55 @@ use glsl::GLSL;
 #[allow(missing_docs)]
 #[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
 pub enum OpenGL {
-    _2_0,
-    _2_1,
-    _3_0,
-    _3_1,
-    _3_2,
-    _3_3,
-    _4_0,
-    _4_1,
-    _4_2,
-    _4_3,
-    _4_4,
-    _4_5
+    V2_0,
+    V2_1,
+    V3_0,
+    V3_1,
+    V3_2,
+    V3_3,
+    V4_0,
+    V4_1,
+    V4_2,
+    V4_3,
+    V4_4,
+    V4_5
 }
 
 impl OpenGL {
     /// Gets the minor version of OpenGL.
     pub fn get_major_minor(&self) -> (isize, isize) {
         match *self {
-            OpenGL::_2_0 => (2, 0),
-            OpenGL::_2_1 => (2, 1),
-            OpenGL::_3_0 => (3, 0),
-            OpenGL::_3_1 => (3, 1),
-            OpenGL::_3_2 => (3, 2),
-            OpenGL::_3_3 => (3, 3),
-            OpenGL::_4_0 => (4, 0),
-            OpenGL::_4_1 => (4, 1),
-            OpenGL::_4_2 => (4, 2),
-            OpenGL::_4_3 => (4, 3),
-            OpenGL::_4_4 => (4, 4),
-            OpenGL::_4_5 => (4, 5)
+            OpenGL::V2_0 => (2, 0),
+            OpenGL::V2_1 => (2, 1),
+            OpenGL::V3_0 => (3, 0),
+            OpenGL::V3_1 => (3, 1),
+            OpenGL::V3_2 => (3, 2),
+            OpenGL::V3_3 => (3, 3),
+            OpenGL::V4_0 => (4, 0),
+            OpenGL::V4_1 => (4, 1),
+            OpenGL::V4_2 => (4, 2),
+            OpenGL::V4_3 => (4, 3),
+            OpenGL::V4_4 => (4, 4),
+            OpenGL::V4_5 => (4, 5)
         }
     }
 
     /// Gets GLSL version associated with OpenGL.
     #[allow(non_snake_case)]
-    pub fn to_GLSL(&self) -> GLSL {
+    pub fn to_glsl(&self) -> GLSL {
         match *self {
-            OpenGL::_2_0 => GLSL::_1_10,
-            OpenGL::_2_1 => GLSL::_1_20,
-            OpenGL::_3_0 => GLSL::_1_30,
-            OpenGL::_3_1 => GLSL::_1_40,
-            OpenGL::_3_2 => GLSL::_1_50,
-            OpenGL::_3_3 => GLSL::_3_30,
-            OpenGL::_4_0 => GLSL::_4_00,
-            OpenGL::_4_1 => GLSL::_4_10,
-            OpenGL::_4_2 => GLSL::_4_20,
-            OpenGL::_4_3 => GLSL::_4_30,
-            OpenGL::_4_4 => GLSL::_4_40,
-            OpenGL::_4_5 => GLSL::_4_50
+            OpenGL::V2_0 => GLSL::V1_10,
+            OpenGL::V2_1 => GLSL::V1_20,
+            OpenGL::V3_0 => GLSL::V1_30,
+            OpenGL::V3_1 => GLSL::V1_40,
+            OpenGL::V3_2 => GLSL::V1_50,
+            OpenGL::V3_3 => GLSL::V3_30,
+            OpenGL::V4_0 => GLSL::V4_00,
+            OpenGL::V4_1 => GLSL::V4_10,
+            OpenGL::V4_2 => GLSL::V4_20,
+            OpenGL::V4_3 => GLSL::V4_30,
+            OpenGL::V4_4 => GLSL::V4_40,
+            OpenGL::V4_5 => GLSL::V4_50
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/shader_version/issues/71

* Bumped to 0.2.0 (breaking change)
* `OpenGL::_3_2` => `OpenGL::V3_2`
* `GLSL::_1_50` => `GLSL::V1_50`
* `GLSL::to_OpenGL` => `GLSL::to_opengl`
* `OpenGL::to_GLSL` => `OpenGL::to_glsl`