### PR TITLE
Derive debug on OpenGL and GLSL enums

### DIFF
--- a/src/glsl.rs
+++ b/src/glsl.rs
@@ -8,7 +8,7 @@ use { OpenGL, PickShader, Shaders };
 /// Source: http://www.opengl.org/wiki/Core_Language_%28GLSL%29
 #[allow(missing_docs)]
 #[allow(non_camel_case_types)]
-#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 pub enum GLSL {
     V1_10,
     V1_20,

--- a/src/opengl.rs
+++ b/src/opengl.rs
@@ -4,7 +4,7 @@ use glsl::GLSL;
 
 #[allow(non_camel_case_types)]
 #[allow(missing_docs)]
-#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 pub enum OpenGL {
     V2_0,
     V2_1,


### PR DESCRIPTION
Hi!

This just adds `Debug` to the derives for `OpenGL` and `GLSL`, which allows them to be used in the `assert_eq!(..., ...)` macro.

If there's reasons not to derive from it, that's okay &mdash; I can live with `assert!(something == OpenGL::Vxxx)`.